### PR TITLE
Add use_tty flag to password command schema

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -163,9 +163,20 @@ auto App::stdin_thread() -> boost::asio::awaitable<void>
     }
 }
 
-auto App::startup() -> void
+auto App::start_input() -> void
 {
     boost::asio::co_spawn(io_context, stdin_thread(), boost::asio::detached);
+}
+
+auto App::stop_input() -> void
+{
+    stdin_poll.cancel();
+    endwin();
+}
+
+auto App::startup() -> void
+{
+    start_input();
     boost::asio::co_spawn(io_context, signal_thread(), boost::asio::detached);
     io_context.run();
 }

--- a/client/app.hpp
+++ b/client/app.hpp
@@ -39,6 +39,9 @@ public:
         return L;
     }
 
+    auto start_input() -> void;
+    auto stop_input() -> void;
+
 private:
     auto signal_thread() -> boost::asio::awaitable<void>;
     auto stdin_thread() -> boost::asio::awaitable<void>;

--- a/client/applib.cpp
+++ b/client/applib.cpp
@@ -253,6 +253,18 @@ auto l_parse_irc(lua_State* const L) -> int
     }
 }
 
+auto l_start_input(lua_State* const L) -> int
+{
+    App::from_lua(L)->start_input();
+    return 0;
+}
+
+auto l_stop_input(lua_State* const L) -> int
+{
+    App::from_lua(L)->stop_input();
+    return 0;
+}
+
 luaL_Reg const applib_module[] = {
     {"connect", l_start_irc},
     {"dnslookup", l_dnslookup},
@@ -270,6 +282,8 @@ luaL_Reg const applib_module[] = {
     {"to_base64", l_to_base64},
     {"xor_strings", l_xor_strings},
     {"execute", l_execute},
+    {"stop_input", l_stop_input},
+    {"start_input", l_start_input},
     {}
 };
 

--- a/dashboard/.luacheckrc
+++ b/dashboard/.luacheckrc
@@ -7,7 +7,8 @@ stds = {
             snowcone = {
                 fields = {"to_base64", "from_base64", "dnslookup", "pton", "shutdown", "newtimer",
                 "setmodule", "raise", "xor_strings", "isalnum", "irccase", "parse_irc_tags",
-                "SIGINT", "SIGTSTP", "connect", "execute", "parse_toml" },
+                "SIGINT", "SIGTSTP", "connect", "execute", "parse_toml",
+                "start_input", "stop_input" },
             },
         },
     },
@@ -18,8 +19,8 @@ stds = {
             "require_", "next_view", "prev_view", "entry_to_kline",
             "add_network_tracker", "quit", "entry_to_unkline",
             "reset_filter", "initialize", "counter_sync_commands",
-            "ctrl", "meta", "status", "plugins", "draw_suspend",
-            "prepare_kline",
+            "ctrl", "meta", "status", "plugins",
+            "prepare_kline", "suspend_tty", "resume_tty",
 
             "conn", "config_dir", "terminal_focus", "configuration",
             "disconnect",

--- a/dashboard/components/Task.lua
+++ b/dashboard/components/Task.lua
@@ -35,8 +35,19 @@ function M:resume(...)
 end
 
 function M:execute(command, args, input)
-    snowcone.execute(command, args or {}, function(...) self:resume(...) end, input)
+    local use_tty = input == nil
+    if use_tty then
+        suspend_tty()
+    end
+    snowcone.execute(command, args or {},
+    function(...)
+        if use_tty then
+            resume_tty()
+        end
+        self:resume(...)
+    end, input)
     return coroutine.yield()
 end
+
 
 return M

--- a/dashboard/handlers/commands.lua
+++ b/dashboard/handlers/commands.lua
@@ -317,7 +317,7 @@ add_command('sasl', '$g', function(name)
     if not entry then
         status('sasl', 'unknown credentials')
     elseif irc_state:has_sasl() then
-        sasl.start(entry)
+        Task(irc_state.tasks, sasl, entry)
     else
         status('sasl', 'sasl not available')
     end

--- a/dashboard/init.lua
+++ b/dashboard/init.lua
@@ -188,7 +188,6 @@ local defaults = {
     editor = Editor(),
     versions = {},
     uptimes = {},
-    draw_suspend = 'no', -- no: draw normally; eligible: don't draw; suspended: a draw is needed
     drains = {},
     sheds = {},
     client_tasks = {},
@@ -595,11 +594,26 @@ function prev_view()
     end
 end
 
-function draw()
-    if draw_suspend ~= 'no' then
-        draw_suspend = 'suspended'
-        return
+
+-- Number of outstanding tty suspends
+local drawing_suspended = 0
+
+function suspend_tty()
+    if drawing_suspended == 0 then
+        snowcone.stop_input()
     end
+    drawing_suspended = drawing_suspended + 1
+end
+
+function resume_tty()
+    drawing_suspended = drawing_suspended - 1
+    if drawing_suspended == 0 then
+        snowcone.start_input()
+    end
+end
+
+function draw()
+    if 0 < drawing_suspended then return end
     clicks = {}
     ncurses.erase()
     normal()

--- a/dashboard/utils/cap_negotiation.lua
+++ b/dashboard/utils/cap_negotiation.lua
@@ -34,7 +34,7 @@ function M.REQ(task, request)
         local credentials = irc_state.sasl_credentials
         irc_state.sasl_credentials = nil
         -- transfer directly into sasl task body
-        sasl(task, credentials, irc_state.phase == 'registration')
+        sasl(task, credentials)
     end
 end
 

--- a/dashboard/utils/configuration_tools.lua
+++ b/dashboard/utils/configuration_tools.lua
@@ -43,7 +43,11 @@ function M.resolve_password(task, entry)
 
     if t == 'table' then
         if entry.command then
-            local exit_code, stdout, stderr = task:execute(entry.command, entry.arguments)
+            local input
+            if not entry.use_tty then
+                input = ''
+            end
+            local exit_code, stdout, stderr = task:execute(entry.command, entry.arguments, input)
             if exit_code == 0 then
                 if entry.multiline then
                     return stdout

--- a/ircc/.luacheckrc
+++ b/ircc/.luacheckrc
@@ -53,6 +53,9 @@ stds = {
             "mode_timestamp", -- uptime value when mode_current changed
             "focus", -- zoomed in message in console
 
+            "suspend_tty", -- stop drawing and processing input
+            "resume_tty", -- resume drawing and processing input
+
             "commands", -- mapping of the global command handlers
             "irc_handlers", -- mapping of IRC message handlers
 

--- a/ircc/.luacheckrc
+++ b/ircc/.luacheckrc
@@ -7,7 +7,8 @@ stds = {
             snowcone = {
               fields = {"to_base64", "from_base64", "dnslookup", "pton", "shutdown", "newtimer",
                 "setmodule", "raise", "xor_strings", "isalnum", "irccase", "parse_irc_tags",
-                "SIGINT", "SIGTSTP", "connect", "parse_irc", "execute", "parse_toml" },
+                "SIGINT", "SIGTSTP", "connect", "parse_irc", "execute", "parse_toml",
+                "start_input", "stop_input" },
             },
         },
     },

--- a/ircc/components/Task.lua
+++ b/ircc/components/Task.lua
@@ -107,7 +107,17 @@ function M:resume(...)
 end
 
 function M:execute(command, args, input)
-    snowcone.execute(command, args or {}, function(...) self:resume(...) end, input)
+    local use_tty = input == nil
+    if use_tty then
+        suspend_tty()
+    end
+    snowcone.execute(command, args or {},
+    function(...)
+        if use_tty then
+            resume_tty()
+        end
+        self:resume(...)
+    end, input)
     return coroutine.yield()
 end
 

--- a/ircc/init.lua
+++ b/ircc/init.lua
@@ -181,20 +181,25 @@ function prev_view()
     end
 end
 
-local drawing_suspended = false
+-- Number of outstanding tty suspends
+local drawing_suspended = 0
 
 function suspend_tty()
-    drawing_suspended = true
-    snowcone.stop_input()
+    if drawing_suspended == 0 then
+        snowcone.stop_input()
+    end
+    drawing_suspended = drawing_suspended + 1
 end
 
 function resume_tty()
-    drawing_suspended = false
-    snowcone.start_input()
+    drawing_suspended = drawing_suspended - 1
+    if drawing_suspended == 0 then
+        snowcone.start_input()
+    end
 end
 
 local function draw()
-    if drawing_suspended then return end;
+    if 0 < drawing_suspended then return end;
 
     clicks = {}
     ncurses.erase()

--- a/ircc/init.lua
+++ b/ircc/init.lua
@@ -181,7 +181,21 @@ function prev_view()
     end
 end
 
+local drawing_suspended = false
+
+function suspend_tty()
+    drawing_suspended = true
+    snowcone.stop_input()
+end
+
+function resume_tty()
+    drawing_suspended = false
+    snowcone.start_input()
+end
+
 local function draw()
+    if drawing_suspended then return end;
+
     clicks = {}
     ncurses.erase()
     main_pad:werase()

--- a/ircc/notification/mac.lua
+++ b/ircc/notification/mac.lua
@@ -19,7 +19,7 @@ function M.notify(previous, buffer, nick, msg)
              '-sound',    'default',
              '-message',  string.format("\\<%s> %s", nick, msg),
              '-group',    tag},
-            report)
+            report, '')
         return tag
     else
         return previous
@@ -27,7 +27,7 @@ function M.notify(previous, buffer, nick, msg)
 end
 
 function M.dismiss(tag)
-    snowcone.execute('terminal-notifier', {'-remove', tag}, report)
+    snowcone.execute('terminal-notifier', {'-remove', tag}, report, '')
 end
 
 return M

--- a/ircc/utils/configuration_schema.lua
+++ b/ircc/utils/configuration_schema.lua
@@ -25,7 +25,8 @@ local command_schema = {
     fields = {
         command = {type = 'string', required = true},
         arguments = {type = 'table', elements = {type = 'string'}},
-        multiline = {type = 'boolean', required = true},
+        multiline = {type = 'boolean'},
+        use_tty = {type = 'boolean'},
     },
 }
 

--- a/ircc/utils/configuration_tools.lua
+++ b/ircc/utils/configuration_tools.lua
@@ -45,16 +45,10 @@ function M.resolve_password(task, entry)
     if t == 'table' then
         if entry.command then
             local input
-            if entry.use_tty then
-                suspend_tty()
-            else
-                -- disconnect stdin from process
+            if not entry.use_tty then
                 input = ''
             end
             local exit_code, stdout, stderr = task:execute(entry.command, entry.arguments, input)
-            if entry.use_tty then
-                resume_tty()
-            end
             if exit_code == 0 then
                 if entry.multiline then
                     return stdout

--- a/ircc/utils/configuration_tools.lua
+++ b/ircc/utils/configuration_tools.lua
@@ -44,7 +44,17 @@ function M.resolve_password(task, entry)
 
     if t == 'table' then
         if entry.command then
-            local exit_code, stdout, stderr = task:execute(entry.command, entry.arguments)
+            local input
+            if entry.use_tty then
+                suspend_tty()
+            else
+                -- disconnect stdin from process
+                input = ''
+            end
+            local exit_code, stdout, stderr = task:execute(entry.command, entry.arguments, input)
+            if entry.use_tty then
+                resume_tty()
+            end
             if exit_code == 0 then
                 if entry.multiline then
                     return stdout


### PR DESCRIPTION
This flag will pause client input processing and UI drawing, but the client will continue processing in the background while waiting for the command to return a password to stdout. In this mode stdin is not redirected.

This enables applications to use /dev/tty to temporarily take control of the terminal to collect credentials